### PR TITLE
WebRTC 114.5735.2.2

### DIFF
--- a/WebRTC/114.5735.2.2/WebRTC.podspec
+++ b/WebRTC/114.5735.2.2/WebRTC.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "WebRTC"
+  s.version      = "114.5735.2.2"
+  s.summary      = "WebRTC library for WebRTC SFU Sora"
+  s.description  = <<-DESC
+                   WebRTC library for WebRTC SFU Sora
+                   DESC
+  s.homepage     = "https://github.com/shiguredo/shiguredo-webrtc-ios"
+  s.license      = { :type => "BSD" }
+  s.authors      = { "WebRTC" => "http://www.webrtc.org",
+                     "Shiguredo Inc." => "https://shiguredo.jp/" }
+  s.platform     = :ios, "13.0"
+  s.source       = { :http => "https://github.com/shiguredo/sora-ios-sdk-specs/releases/download/#{s.name}-#{s.version}/WebRTC.xcframework.zip" }
+  s.vendored_frameworks = "WebRTC.xcframework"
+end


### PR DESCRIPTION
WebRTC 114.5735.2.2 の Podspec を追加します。 CocoaPods によるダウンロードの確認のために一旦リリースを作成しましたが、マージ後に作り直します。

https://github.com/shiguredo/sora-ios-sdk-specs/releases/tag/WebRTC-114.5735.2.2