### PR TITLE
README にある Podfile の CocoaPods のソースリポジトリ URL を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ $ pod repo update
 Podfile の先頭に次の記述を追加することで、本リポジトリの Spec を利用可能になります。
 
 ```
+source 'https://cdn.cocoapods.org/'
 source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
-source 'https://github.com/CocoaPods/Specs.git'
 ```
 
 ## ライセンス


### PR DESCRIPTION
CocoaPods 1.8 からソースリポジトリのデフォルトが https://cdn.cocoapods.org/ になったため、 README の Podfile に記載の CocoaPods のソースリポジトリ URL を変更しました。

参考: https://blog.cocoapods.org/CocoaPods-1.8.0-beta/

---

This pull request includes a change to the `README.md` file, specifically in the section about updating the pod repository. The source URL for CocoaPods has been replaced with a different URL, while a new source URL has been added.

Change details:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-L35): The source URL `https://github.com/CocoaPods/Specs.git` has been removed from the Podfile instructions, and `https://cdn.cocoapods.org/` has been added. This means that the spec for this repository will now use a different source for CocoaPods.